### PR TITLE
Bugfix: Invalid name character in 'http://schemas.microsoft.com/2004/09/ServiceModel/Diagnostics'. The ':' character, hexadecimal value 0x3A, cannot be included in a name.

### DIFF
--- a/burp_wcf_plugin/src/NBFS.cs
+++ b/burp_wcf_plugin/src/NBFS.cs
@@ -209,6 +209,7 @@ public static class WcfDictionaryBuilder
         dict.Add("Transforms");
         dict.Add("Transform");
         dict.Add("DigestMethod");
+        dict.Add("DigestValue");
         dict.Add("Address");
         dict.Add("ReplyTo");
         dict.Add("SequenceAcknowledgement");


### PR DESCRIPTION
Added missing "DigestValue" to dictionary
ref: https://msdn.microsoft.com/en-us/library/cc219187.aspx
This fixes invalid XML exception:
Invalid name character in 'http://schemas.microsoft.com/2004/09/ServiceModel/Diagnostics'. The ':' character, hexadecimal value 0x3A, cannot be included in a name.